### PR TITLE
fix: add pytest>=7.4.0to dashboard/requirement.txt

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.2.1
 gunicorn==21.2.0
 certifi
 pytz
+pytest>=7.4.0


### PR DESCRIPTION
pytest was missing from the dashboard requirements, causing test runs to fail when setting up the environment from scratch.
