### PR TITLE
security: pin action SHAs and restrict workflow permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,16 +6,19 @@ on:
   pull_request:
     branches: [production]
 
+permissions: 
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## What changed
- Added `permissions: contents: read` to restrict the workflow token to read-only access
- Pinned `actions/checkout` to exact commit SHA (v6) instead of floating tag
- Pinned `actions/setup-python` to exact commit SHA (v6.2.0) instead of floating tag

## Why
Protection against two attack vectors seen in recent GitHub Actions supply chain attacks:
- Floating tags like @v4 can be silently replaced with malicious code
- Default broad token permissions allow attackers to delete code/releases if runner is compromised
