### PR TITLE
fix: remove broken license reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,4 +420,4 @@ Feature Branch → Pull Request → CI Check → Merge → Manual Deploy
 </a>
 
 ## 📝 License
-This project is licensed under the MIT License, see the [LICENSE](LICENSE) file for details.
+This project is part of SE4CPS coursework.


### PR DESCRIPTION
What
- Removes the broken LICENSE reference from the production README

Why
- The README pointed to a LICENSE file that is not currently present on the production branch
- This change keeps the README aligned with the actual repository state

Notes
- No production code changed
- README cleanup only